### PR TITLE
Fixed issue #6 - Add option to open link directly in browser

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,94 @@
+# Citizen Code of Conduct
+
+## 1. Purpose
+
+A primary goal of Ghpr is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in Ghpr to help us create safe and positive experiences for everyone.
+
+## 2. Open [Source/Culture/Tech] Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+## 3. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+ * Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+ * Exercise consideration and respect in your speech and actions.
+ * Attempt collaboration before conflict.
+ * Refrain from demeaning, discriminatory, or harassing behavior and speech.
+ * Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+ * Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+## 4. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+ * Violence, threats of violence or violent language directed against another person.
+ * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+ * Posting or displaying sexually explicit or violent material.
+ * Posting or threatening to post other people's personally identifying information ("doxing").
+ * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+ * Inappropriate photography or recording.
+ * Inappropriate physical contact. You should have someone's consent before touching them.
+ * Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+ * Deliberate intimidation, stalking or following (online or in person).
+ * Advocating for, or encouraging, any of the above behavior.
+ * Sustained disruption of community events, including talks and presentations.
+
+## 5. Weapons Policy
+
+No weapons will be allowed at Ghpr events, community spaces, or in other spaces covered by the scope of this Code of Conduct. Weapons include but are not limited to guns, explosives (including fireworks), and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others. Anyone seen in possession of one of these items will be asked to leave immediately, and will only be allowed to return without the weapon. Community members are further expected to comply with all state and local laws on this matter.
+
+## 6. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+## 7. Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. .
+
+
+
+Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+## 8. Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Maintainers of this repository with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. 
+
+
+
+## 9. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
+
+This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
+
+## 10. Contact info
+
+
+
+## 11. License and attribution
+
+The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+
+Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+_Revision 2.3. Posted 6 March 2017._
+
+_Revision 2.2. Posted 4 February 2016._
+
+_Revision 2.1. Posted 23 June 2014._
+
+_Revision 2.0, adopted by the [Stumptown Syndicate](http://stumptownsyndicate.org) board on 10 January 2013. Posted 17 March 2013._

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ clap = { version = "4.0", features = ["derive"] }
 config = "0.13"
 git2 = "0.19"
 percent-encoding = "2.3.1"
-# Add this dependency for opening URLs in the default browser
 webbrowser = "0.8"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ clap = { version = "4.0", features = ["derive"] }
 config = "0.13"
 git2 = "0.19"
 percent-encoding = "2.3.1"
-
+# Add this dependency for opening URLs in the default browser
+webbrowser = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.0", features = ["derive"] }
 config = "0.13"
 git2 = "0.19"
 percent-encoding = "2.3.1"
-webbrowser = "0.8"
+webbrowser = "1.0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Readme.md
+++ b/Readme.md
@@ -74,7 +74,7 @@ The .ghprrc file allows you to set default values for various parameters used in
 ```ini
 [defaults]
 repo = "owner/repo"
-src = "feature-branch
+src = "feature-branch"
 dest = "main"
 title = "Your PR Title"
 body = "Description of the pull request."

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# 🦀 GitHub PR URL Generator
+# 🦀 Github PR URL Generator
 
 Welcome to the **GitHub PR URL Generator**! This command-line tool simplifies the creation of pull request for your GitHub repositories.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # 🦀 GitHub PR URL Generator
 
-Welcome to the **GitHub PR URL Generator**! This command-line tool simplifies the creation of pull request URLs for your GitHub repositories with customizable parameters.
+Welcome to the **GitHub PR URL Generator**! This command-line tool simplifies the creation of pull request for your GitHub repositories.
 
 To create a PR quickly, run the command and click the generated link.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,9 +192,11 @@ fn main() {
 }
 
 fn get_config_value<'a>(matches: &clap::ArgMatches, config: Option<&RcFile>, key: &str) -> String {
+    // Check matches first
     let value_from_matches: Option<&str> =
         matches.get_one::<String>(key).map(|s: &String| s.as_str());
 
+    // If no value found, check the config
     let value_from_config: Option<&str> = config.and_then(|cfg: &RcFile| {
         cfg.defaults
             .as_ref()
@@ -202,10 +204,13 @@ fn get_config_value<'a>(matches: &clap::ArgMatches, config: Option<&RcFile>, key
             .map(|s: &String| s.as_str())
     });
 
+    // Combine both options
     value_from_matches
         .or(value_from_config)
         .map(|s: &str| s.to_string())
-        .unwrap_or_else(|| String::new())
+        .unwrap_or_else(|| {
+            String::new() // or provide a default string if needed
+        })
 }
 
 fn read_config(file_path: &str) -> Option<RcFile> {
@@ -220,17 +225,22 @@ fn read_config(file_path: &str) -> Option<RcFile> {
 
             Some(RcFile { defaults })
         }
-        Err(_e) => None,
+        Err(_e) => {
+            // eprintln!("Error reading config: {}", e);
+            None
+        }
     }
 }
 
 fn get_current_branch_name() -> Option<String> {
     match Repository::discover(".") {
         Ok(repo) => {
+            // try to get the head reference
             match repo.head() {
                 Ok(head) => {
                     if let Some(branch) = head.shorthand() {
                         return Some(branch.to_string());
+                    } else {
                     }
                 }
                 Err(_e) => {}


### PR DESCRIPTION
This PR addresses issue #6 for Hacktoberfest by adding the -o or --open option, allowing users to directly open the generated pull request URL in their default browser.

**Changes Made**
  Added a command-line argument to open the URL automatically using the open crate.

  **How to Test**
  _Run the command:_
          cargo run -- -r owner/repo -b my-feature-branch -d main -o

Thank you for considering this contribution!